### PR TITLE
manifest: Update to Zephyr 3.7.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -15,7 +15,7 @@ manifest:
       path: modules/hal/silabs
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      revision: 36940db938a8f4a1e919496793ed439850a221c2
       import:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.


### PR DESCRIPTION
Set the manifest to point at the Zephyr 3.7.0 release commit for now.