### PR TITLE
silabs: siwg917: Fix memory definitions

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.yaml
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.yaml
@@ -2,7 +2,7 @@ identifier: siwx917_rb4338a
 name: SiWx917 Wi-Fi 6 and Bluetooth LE 8MB Flash Radio Board
 type: mcu
 arch: arm
-ram: 196
+ram: 191
 flash: 1024
 toolchain:
   - zephyr

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -19,12 +19,12 @@
 		};
 	};
 
-	sram0: memory@400 {
+	sram0: memory@0 {
 		compatible = "mmio-sram";
 		reg = <0x00000000 DT_SIZE_K(191)>;
 	};
 
-	flash0: flash@8212000 {
+	flash0: flash@8202000 {
 		compatible = "soc-nv-flash";
 		reg = <0x8202000 DT_SIZE_K(2040)>;
 	};


### PR DESCRIPTION
Fix the unit path definitions for flash and RAM, and make sure the board
yaml file is in sync with DTS.