### PR TITLE
github: compliance: Disable KconfigHWMv2 check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -36,7 +36,10 @@ jobs:
       working-directory: zephyr-silabs
       run: |
         export ZEPHYR_BASE="$(dirname "$(pwd)")/zephyr"
-        $ZEPHYR_BASE/scripts/ci/check_compliance.py --annotate -e Kconfig -e KconfigBasic -c origin/${GITHUB_BASE_REF}..
+        # FIXME: We should be able to run KconfigHWMv2, but right now it doesn't seem
+        # to handle our soc directory correctly.
+        $ZEPHYR_BASE/scripts/ci/check_compliance.py --annotate -e Kconfig -e KconfigBasic \
+        -e KconfigHWMv2 -c origin/${GITHUB_BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Disable the KconfigHWMv2 check in the compliance workflow. This should work, but right now it seems broken in that it doesn't seem to recognize valid SoC Kconfig symbols in the zephyr-silabs soc directory.

This is (hopefully) just a temporary workaround, but it's better than having the compliance check fail and cause unnecessary noise for pull requests.