### PR TITLE
drivers: gpio: siwx917: Add GPIO driver

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
@@ -6,6 +6,8 @@
 
 /dts-v1/;
 #include <silabs/siwg917m111mgtba.dtsi>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "Silicon Labs BRD4338A (SiWG917 Radio Board)";
@@ -16,6 +18,36 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &ulpuart0;
 		zephyr,shell-uart = &ulpuart0;
+	};
+
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		sw0 = &button0;
+		sw1 = &button1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&ulpgpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		led1: led_1 {
+			gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&uulpgpio 2 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+		button1: button_1 {
+			gpios = <&gpioa 11 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_1>;
+		};
 	};
 };
 

--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.yaml
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.yaml
@@ -8,3 +8,6 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - gpio
+vendor: silabs

--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources_ifdef(CONFIG_GPIO_SILABS_SIWX917 gpio_silabs_siwx917.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO_SILABS_SIWX917_UULP gpio_silabs_siwx917_uulp.c)

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -1,5 +1,8 @@
 # Copyright (c) 2024 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(gpio)
-add_subdirectory(pinctrl)
+if GPIO
+
+rsource "Kconfig.siwx917"
+
+endif

--- a/drivers/gpio/Kconfig.siwx917
+++ b/drivers/gpio/Kconfig.siwx917
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig GPIO_SILABS_SIWX917
+	bool "Silabs SiWx917 GPIO driver"
+	default y
+	depends on DT_HAS_SILABS_SIWX917_GPIO_ENABLED
+	help
+	  Enable the HP/ULP GPIO driver for the Silabs SiWx917 SoC series.
+
+config GPIO_SILABS_SIWX917_COMMON_INIT_PRIORITY
+	int "Common initialization priority"
+	depends on GPIO_SILABS_SIWX917
+	default 39
+
+config GPIO_SILABS_SIWX917_UULP
+	bool "Silabs SiWx917 UULP GPIO driver"
+	default y
+	depends on DT_HAS_SILABS_SIWX917_GPIO_UULP_ENABLED
+	help
+	  Enable the UULP GPIO driver for the Silabs SiWx917 SoC series.

--- a/drivers/gpio/gpio_silabs_siwx917.c
+++ b/drivers/gpio/gpio_silabs_siwx917.c
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2024 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT silabs_siwx917_gpio
+
+#include "sl_si91x_driver_gpio.h"
+#include "sl_status.h"
+
+#include <errno.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/irq.h>
+
+/* Zephyr GPIO header must be included after driver, due to symbol conflicts
+ * for GPIO_INPUT and GPIO_OUTPUT between preprocessor macros in the Zephyr
+ * API and struct member register definitions for the SiWx917 device.
+ */
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/gpio/gpio_utils.h>
+
+#if CONFIG_GPIO_SILABS_SIWX917_COMMON_INIT_PRIORITY >= CONFIG_GPIO_INIT_PRIORITY
+#error CONFIG_GPIO_SILABS_SIWX917_COMMON_INIT_PRIORITY must be less than \
+	CONFIG_GPIO_INIT_PRIORITY.
+#endif
+
+#define MAX_PORT_COUNT  4
+#define MAX_PIN_COUNT   16
+#define INVALID_PORT    0xFF
+#define INTERRUPT_COUNT 8
+
+/* Types */
+struct gpio_siwx917_common_config {
+	EGPIO_Type *reg;
+};
+
+struct gpio_siwx917_port_config {
+	/* gpio_driver_config needs to be first */
+	struct gpio_driver_config common;
+	const struct device *parent;
+	uint8_t pads[MAX_PIN_COUNT];
+	int port;
+	int hal_port;
+	bool ulp;
+};
+
+struct gpio_siwx917_common_data {
+	/* a list of all ports */
+	const struct device *ports[MAX_PORT_COUNT];
+	sl_gpio_t interrupts[INTERRUPT_COUNT];
+};
+
+struct gpio_siwx917_port_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
+	/* port ISR callback routine address */
+	sys_slist_t callbacks;
+};
+
+/* Functions */
+static int gpio_siwx917_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
+{
+	const struct gpio_siwx917_port_config *cfg = dev->config;
+	const struct device *parent = cfg->parent;
+	const struct gpio_siwx917_common_config *pcfg = parent->config;
+	sl_status_t status;
+	sl_si91x_gpio_driver_disable_state_t disable_state = GPIO_HZ;
+
+	if (flags & GPIO_SINGLE_ENDED) {
+		return -ENOTSUP;
+	}
+
+	uint8_t pad = cfg->pads[pin];
+
+	if (pad == 0) {
+		/* Enable MCU pad */
+		status = sl_si91x_gpio_driver_enable_host_pad_selection((cfg->hal_port << 4) | pin);
+		if (status != SL_STATUS_OK) {
+			return -ENODEV;
+		}
+	} else if (pad != 0xFF && pad != 9) {
+		/* Assign pad to MCU subsystem */
+		status = sl_si91x_gpio_driver_enable_pad_selection(pad);
+		if (status != SL_STATUS_OK) {
+			return -ENODEV;
+		}
+	}
+
+	if (flags & GPIO_PULL_UP) {
+		disable_state = GPIO_PULLUP;
+	} else if (flags & GPIO_PULL_DOWN) {
+		disable_state = GPIO_PULLDOWN;
+	}
+	if (cfg->ulp) {
+		sl_si91x_gpio_select_ulp_pad_driver_disable_state(pin, disable_state);
+	} else {
+		sl_si91x_gpio_select_pad_driver_disable_state((cfg->port << 4) | pin,
+							      disable_state);
+	}
+
+	if (flags & GPIO_INPUT) {
+		if (cfg->ulp) {
+			sl_si91x_gpio_driver_enable_ulp_pad_receiver(pin);
+		} else {
+			sl_si91x_gpio_driver_enable_pad_receiver((cfg->port << 4) | pin);
+		}
+	} else {
+		if (cfg->ulp) {
+			sl_si91x_gpio_driver_disable_ulp_pad_receiver(pin);
+		} else {
+			sl_si91x_gpio_driver_disable_pad_receiver((cfg->port << 4) | pin);
+		}
+	}
+
+	pcfg->reg->PIN_CONFIG[(cfg->port << 4) + pin].GPIO_CONFIG_REG_b.MODE = 0;
+
+	if (flags & GPIO_OUTPUT_INIT_HIGH) {
+		sl_gpio_set_pin_output(cfg->hal_port, pin);
+	} else if (flags & GPIO_OUTPUT_INIT_LOW) {
+		sl_gpio_clear_pin_output(cfg->hal_port, pin);
+	}
+
+	sl_si91x_gpio_set_pin_direction(cfg->hal_port, pin, (flags & GPIO_OUTPUT) ? 0 : 1);
+
+	return 0;
+}
+
+static int gpio_siwx917_port_get(const struct device *port, gpio_port_value_t *value)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+
+	*value = sl_gpio_get_port_input(cfg->hal_port);
+
+	return 0;
+}
+
+static int gpio_siwx917_port_set_masked(const struct device *port, gpio_port_pins_t mask,
+					gpio_port_value_t value)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+	const struct device *parent = cfg->parent;
+	const struct gpio_siwx917_common_config *pcfg = parent->config;
+
+	/* Cannot use HAL function sl_gpio_set_port_output_value(), as it doesn't clear bits. */
+	pcfg->reg->PORT_CONFIG[cfg->port].PORT_LOAD_REG =
+		(pcfg->reg->PORT_CONFIG[cfg->port].PORT_LOAD_REG & ~mask) | (value & mask);
+
+	return 0;
+}
+
+static int gpio_siwx917_port_set_bits(const struct device *port, gpio_port_pins_t pins)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+
+	sl_gpio_set_port_output(cfg->hal_port, pins);
+
+	return 0;
+}
+
+static int gpio_siwx917_port_clear_bits(const struct device *port, gpio_port_pins_t pins)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+
+	sl_gpio_clear_port_output(cfg->hal_port, pins);
+
+	return 0;
+}
+
+static int gpio_siwx917_port_toggle_bits(const struct device *port, gpio_port_pins_t pins)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+
+	sl_gpio_toggle_port_output(cfg->hal_port, pins);
+
+	return 0;
+}
+
+static bool receiver_enabled(bool ulp, sl_gpio_port_t port, int pin)
+{
+	if (ulp) {
+		return ULP_PAD_CONFIG_REG & BIT(pin);
+	} else {
+		return PAD_REG(((port << 4) | pin))->GPIO_PAD_CONFIG_REG_b.PADCONFIG_REN;
+	}
+}
+
+int gpio_siwx917_port_get_direction(const struct device *port, gpio_port_pins_t map,
+				    gpio_port_pins_t *inputs, gpio_port_pins_t *outputs)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+
+	if (inputs != NULL) {
+		*inputs = 0;
+	}
+	if (outputs != NULL) {
+		*outputs = 0;
+	}
+	for (int i = 0; i < MAX_PIN_COUNT; i++) {
+		if ((map & BIT(i))) {
+			if (sl_si91x_gpio_get_pin_direction(cfg->hal_port, i) == 0) {
+				if (outputs != NULL) {
+					*outputs |= BIT(i);
+				}
+			}
+			if (receiver_enabled(cfg->ulp, cfg->port, i)) {
+				if (inputs != NULL) {
+					*inputs |= BIT(i);
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+static int gpio_siwx917_manage_callback(const struct device *port, struct gpio_callback *callback,
+					bool set)
+{
+	struct gpio_siwx917_port_data *data = port->data;
+
+	return gpio_manage_callback(&data->callbacks, callback, set);
+}
+
+static int gpio_siwx917_interrupt_configure(const struct device *port, gpio_pin_t pin,
+					    enum gpio_int_mode mode, enum gpio_int_trig trig)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+	const struct device *parent = cfg->parent;
+	const struct gpio_siwx917_common_config *pcfg = parent->config;
+	struct gpio_siwx917_common_data *data = parent->data;
+	sl_si91x_gpio_interrupt_config_flag_t flags = 0;
+
+	if (mode & GPIO_INT_DISABLE) {
+		ARRAY_FOR_EACH(data->interrupts, i) {
+			if (data->interrupts[i].port == cfg->port &&
+			    data->interrupts[i].pin == pin) {
+				data->interrupts[i].port = INVALID_PORT;
+				if (cfg->ulp) {
+					sl_si91x_gpio_configure_ulp_pin_interrupt(i, flags, pin);
+				} else {
+					sl_gpio_configure_interrupt(cfg->port, pin, i, flags);
+				}
+				/* Configure function doesn't mask interrupts when disabling */
+				pcfg->reg->INTR[i].GPIO_INTR_CTRL_b.MASK = 1;
+				if (cfg->ulp) {
+					sl_si91x_gpio_clear_ulp_interrupt(i);
+				} else {
+					sl_gpio_clear_interrupts(i);
+				}
+				return 0;
+			}
+		}
+		/* No interrupt to disable, but this is not an error */
+		return 0;
+	}
+
+	if (trig == GPIO_INT_TRIG_LOW) {
+		flags = (mode == GPIO_INT_MODE_EDGE) ? SL_GPIO_INTERRUPT_FALL_EDGE
+						     : SL_GPIO_INTERRUPT_LEVEL_LOW;
+	} else if (trig == GPIO_INT_TRIG_HIGH) {
+		flags = (mode == GPIO_INT_MODE_EDGE) ? SL_GPIO_INTERRUPT_RISE_EDGE
+						     : SL_GPIO_INTERRUPT_LEVEL_HIGH;
+	} else if (trig == GPIO_INT_TRIG_BOTH) {
+		/* SL_GPIO_INTERRUPT_RISE_FALL_EDGE would make more sense, but HAL
+		 * implementation is buggy.
+		 */
+		flags = SL_GPIO_INTERRUPT_RISE_EDGE | SL_GPIO_INTERRUPT_FALL_EDGE;
+	}
+
+	ARRAY_FOR_EACH(data->interrupts, i) {
+		if (data->interrupts[i].port == INVALID_PORT ||
+		    (data->interrupts[i].port == cfg->port && data->interrupts[i].pin == pin)) {
+			data->interrupts[i].port = cfg->port;
+			data->interrupts[i].pin = pin;
+
+			if (cfg->ulp) {
+				sl_si91x_gpio_configure_ulp_pin_interrupt(i, flags, pin);
+			} else {
+				sl_gpio_configure_interrupt(cfg->port, pin, i, flags);
+			}
+			return 0;
+		}
+	}
+	/* No more available interrupts */
+	return -EBUSY;
+}
+
+static inline int gpio_siwx917_init_port(const struct device *port)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+	const struct device *parent = cfg->parent;
+	struct gpio_siwx917_common_data *data = parent->data;
+
+	/* Register port as active */
+	__ASSERT(cfg->port < MAX_PORT_COUNT, "Too many ports");
+	data->ports[cfg->port] = port;
+
+	return 0;
+}
+
+static void gpio_siwx917_isr(const struct device *parent)
+{
+	const struct gpio_siwx917_common_config *pcfg = parent->config;
+	struct gpio_siwx917_common_data *common = parent->data;
+	const struct device *port;
+	struct gpio_siwx917_port_data *data;
+
+	ARRAY_FOR_EACH(common->interrupts, i) {
+		sl_gpio_port_t port_no = common->interrupts[i].port;
+		uint32_t pending = pcfg->reg->INTR[i].GPIO_INTR_STATUS_b.INTERRUPT_STATUS;
+
+		if (pending && port_no != INVALID_PORT) {
+			/* Clear interrupt */
+			pcfg->reg->INTR[i].GPIO_INTR_STATUS_b.INTERRUPT_STATUS = 1;
+			port = common->ports[port_no];
+			data = port->data;
+			gpio_fire_callbacks(&data->callbacks, port, BIT(common->interrupts[i].pin));
+		}
+	}
+}
+
+static uint32_t gpio_siwx917_get_pending_int(const struct device *port)
+{
+	const struct gpio_siwx917_port_config *cfg = port->config;
+	const struct device *parent = cfg->parent;
+	const struct gpio_siwx917_common_config *pcfg = parent->config;
+	uint32_t status = 0;
+
+	ARRAY_FOR_EACH(pcfg->reg->INTR, i) {
+		if (pcfg->reg->INTR[i].GPIO_INTR_STATUS_b.INTERRUPT_STATUS) {
+			status |= BIT(i);
+		}
+	}
+	return status;
+}
+
+static const struct gpio_driver_api gpio_siwx917_driver_api = {
+	.pin_configure = gpio_siwx917_pin_configure,
+	.port_get_raw = gpio_siwx917_port_get,
+	.port_set_masked_raw = gpio_siwx917_port_set_masked,
+	.port_set_bits_raw = gpio_siwx917_port_set_bits,
+	.port_clear_bits_raw = gpio_siwx917_port_clear_bits,
+	.port_toggle_bits = gpio_siwx917_port_toggle_bits,
+	.pin_interrupt_configure = gpio_siwx917_interrupt_configure,
+	.manage_callback = gpio_siwx917_manage_callback,
+	.get_pending_int = gpio_siwx917_get_pending_int,
+#ifdef CONFIG_GPIO_GET_DIRECTION
+	.port_get_direction = gpio_siwx917_port_get_direction,
+#endif
+};
+
+#define GPIO_PORT_INIT(n)                                                                          \
+	static const struct gpio_siwx917_port_config gpio_siwx917_port_##n##_config = {            \
+		.common =                                                                          \
+			{                                                                          \
+				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_NODE(n),               \
+			},                                                                         \
+		.parent = DEVICE_DT_GET(DT_PARENT(n)),                                             \
+		.pads = DT_PROP(n, silabs_pads),                                                   \
+		.port = DT_REG_ADDR(n),                                                            \
+		.hal_port = (DT_PROP(DT_PARENT(n), silabs_ulp) ? SL_GPIO_ULP_PORT : 0) +           \
+			    DT_REG_ADDR(n),                                                        \
+		.ulp = DT_PROP(DT_PARENT(n), silabs_ulp),                                          \
+	};                                                                                         \
+	static struct gpio_siwx917_port_data gpio_siwx917_port_##n##_data;                         \
+                                                                                                   \
+	DEVICE_DT_DEFINE(n, gpio_siwx917_init_port, NULL, &gpio_siwx917_port_##n##_data,           \
+			 &gpio_siwx917_port_##n##_config, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY, \
+			 &gpio_siwx917_driver_api);
+
+#define CONFIGURE_SHARED_INTERRUPT(node_id, prop, idx)                                             \
+	IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, idx, irq), DT_IRQ_BY_IDX(node_id, idx, priority),       \
+		    gpio_siwx917_isr, DEVICE_DT_GET(node_id), 0);                                  \
+	irq_enable(DT_IRQ_BY_IDX(node_id, idx, irq));
+
+static const struct gpio_driver_api gpio_siwx917_common_driver_api = {};
+
+#define GPIO_CONTROLLER_INIT(idx)                                                                  \
+	static int gpio_siwx917_init_controller_##idx##_(const struct device *dev);                \
+	static const struct gpio_siwx917_common_config gpio_siwx917_##idx##_config = {             \
+		.reg = (EGPIO_Type *)DT_INST_REG_ADDR(idx),                                        \
+	};                                                                                         \
+	static struct gpio_siwx917_common_data gpio_siwx917_##idx##_data;                          \
+	DEVICE_DT_INST_DEFINE(idx, gpio_siwx917_init_controller_##idx##_, NULL,                    \
+			      &gpio_siwx917_##idx##_data, &gpio_siwx917_##idx##_config,            \
+			      PRE_KERNEL_1, CONFIG_GPIO_SILABS_SIWX917_COMMON_INIT_PRIORITY,       \
+			      &gpio_siwx917_common_driver_api);                                    \
+	static int gpio_siwx917_init_controller_##idx##_(const struct device *dev)                 \
+	{                                                                                          \
+		struct gpio_siwx917_common_data *data = dev->data;                                 \
+		sl_status_t status = sl_si91x_gpio_driver_enable_clock(                            \
+			COND_CODE_1(DT_INST_PROP(idx, silabs_ulp), (ULPCLK_GPIO), (M4CLK_GPIO)));  \
+		if (status != SL_STATUS_OK) {                                                      \
+			return -ENODEV;                                                            \
+		}                                                                                  \
+		ARRAY_FOR_EACH(data->interrupts, i) {                                              \
+			data->interrupts[i].port = INVALID_PORT;                                   \
+		}                                                                                  \
+		DT_INST_FOREACH_PROP_ELEM(idx, interrupt_names, CONFIGURE_SHARED_INTERRUPT);       \
+		return 0;                                                                          \
+	}                                                                                          \
+	DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, GPIO_PORT_INIT);
+
+DT_INST_FOREACH_STATUS_OKAY(GPIO_CONTROLLER_INIT)

--- a/drivers/gpio/gpio_silabs_siwx917_uulp.c
+++ b/drivers/gpio/gpio_silabs_siwx917_uulp.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2024 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT silabs_siwx917_gpio_uulp
+
+#include "sl_si91x_driver_gpio.h"
+#include "sl_status.h"
+
+#include <errno.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/irq.h>
+
+/* Zephyr GPIO header must be included after driver, due to symbol conflicts
+ * for GPIO_INPUT and GPIO_OUTPUT between preprocessor macros in the Zephyr
+ * API and struct member register definitions for the SiWx917 device.
+ */
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/gpio/gpio_utils.h>
+
+#define UULP_GPIO_COUNT           5
+#define UULP_REG_INTERRUPT_CONFIG 0x10
+
+/* Types */
+struct gpio_siwx917_uulp_config {
+	/* gpio_driver_config needs to be first */
+	struct gpio_driver_config common;
+};
+
+struct gpio_siwx917_uulp_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
+	/* port ISR callback routine address */
+	sys_slist_t callbacks;
+};
+
+/* Functions */
+static int gpio_siwx917_uulp_pin_configure(const struct device *dev, gpio_pin_t pin,
+					   gpio_flags_t flags)
+{
+	if (flags & (GPIO_SINGLE_ENDED | GPIO_PULL_UP | GPIO_PULL_DOWN)) {
+		return -ENOTSUP;
+	}
+
+	/* Enable input */
+	sl_si91x_gpio_select_uulp_npss_receiver(pin, (flags & GPIO_INPUT) ? 1 : 0);
+
+	/* Select GPIO mode */
+	sl_si91x_gpio_set_uulp_npss_pin_mux(pin, 0);
+
+	if (flags & GPIO_OUTPUT_INIT_HIGH) {
+		sl_si91x_gpio_set_uulp_npss_pin_value(pin, 1);
+	} else if (flags & GPIO_OUTPUT_INIT_LOW) {
+		sl_si91x_gpio_set_uulp_npss_pin_value(pin, 0);
+	}
+
+	/* Enable output */
+	sl_si91x_gpio_set_uulp_npss_direction(pin, (flags & GPIO_OUTPUT) ? 0 : 1);
+
+	return 0;
+}
+
+static int gpio_siwx917_uulp_port_get(const struct device *port, gpio_port_value_t *value)
+{
+	for (size_t i = 0; i < UULP_GPIO_COUNT; i++) {
+		WRITE_BIT(*value, i, sl_si91x_gpio_get_uulp_npss_pin(i));
+	}
+
+	return 0;
+}
+
+static int gpio_siwx917_uulp_port_set_masked(const struct device *port, gpio_port_pins_t mask,
+					     gpio_port_value_t value)
+{
+	for (size_t i = 0; i < UULP_GPIO_COUNT; i++) {
+		if (mask & BIT(i)) {
+			sl_si91x_gpio_set_uulp_npss_pin_value(i, FIELD_GET(BIT(i), value));
+		}
+	}
+
+	return 0;
+}
+
+static int gpio_siwx917_uulp_port_set_bits(const struct device *port, gpio_port_pins_t pins)
+{
+	for (size_t i = 0; i < UULP_GPIO_COUNT; i++) {
+		if (FIELD_GET(BIT(i), pins)) {
+			sl_si91x_gpio_set_uulp_npss_pin_value(i, 1);
+		}
+	}
+
+	return 0;
+}
+
+static int gpio_siwx917_uulp_port_clear_bits(const struct device *port, gpio_port_pins_t pins)
+{
+	for (size_t i = 0; i < UULP_GPIO_COUNT; i++) {
+		if (FIELD_GET(BIT(i), pins)) {
+			sl_si91x_gpio_set_uulp_npss_pin_value(i, 0);
+		}
+	}
+
+	return 0;
+}
+
+static int gpio_siwx917_uulp_port_toggle_bits(const struct device *port, gpio_port_pins_t pins)
+{
+	for (size_t i = 0; i < UULP_GPIO_COUNT; i++) {
+		if (FIELD_GET(BIT(i), pins)) {
+			sl_si91x_gpio_toggle_uulp_npss_pin(i);
+		}
+	}
+
+	return 0;
+}
+
+static int gpio_siwx917_uulp_manage_callback(const struct device *port,
+					     struct gpio_callback *callback, bool set)
+{
+	struct gpio_siwx917_uulp_data *data = port->data;
+
+	return gpio_manage_callback(&data->callbacks, callback, set);
+}
+
+static int gpio_siwx917_uulp_interrupt_configure(const struct device *port, gpio_pin_t pin,
+						 enum gpio_int_mode mode, enum gpio_int_trig trig)
+{
+	uint32_t flags = 0;
+
+	if (mode == GPIO_INT_MODE_DISABLED) {
+		sl_si91x_gpio_configure_uulp_interrupt(flags, pin);
+		sl_si91x_gpio_clear_uulp_interrupt(BIT(pin));
+		sl_si91x_gpio_mask_uulp_npss_interrupt(BIT(pin));
+	} else {
+		if (trig == GPIO_INT_TRIG_LOW) {
+			flags = (mode == GPIO_INT_MODE_EDGE) ? SL_GPIO_INTERRUPT_FALL_EDGE
+							     : SL_GPIO_INTERRUPT_LEVEL_LOW;
+		} else if (trig == GPIO_INT_TRIG_HIGH) {
+			flags = (mode == GPIO_INT_MODE_EDGE) ? SL_GPIO_INTERRUPT_RISE_EDGE
+							     : SL_GPIO_INTERRUPT_LEVEL_HIGH;
+		} else if (trig == GPIO_INT_TRIG_BOTH) {
+			/* SL_GPIO_INTERRUPT_RISE_FALL_EDGE would make more sense, but HAL
+			 * implementation is buggy.
+			 */
+			flags = SL_GPIO_INTERRUPT_RISE_EDGE | SL_GPIO_INTERRUPT_FALL_EDGE;
+		}
+
+		sl_si91x_gpio_configure_uulp_interrupt(flags, pin);
+	}
+	return 0;
+}
+
+static void gpio_siwx917_uulp_isr(const struct device *port)
+{
+	struct gpio_siwx917_uulp_data *data = port->data;
+	uint8_t pins = sl_si91x_gpio_get_uulp_interrupt_status();
+
+	sl_si91x_gpio_clear_uulp_interrupt(pins);
+
+	gpio_fire_callbacks(&data->callbacks, port, pins);
+}
+
+static const struct gpio_driver_api gpio_siwx917_uulp_driver_api = {
+	.pin_configure = gpio_siwx917_uulp_pin_configure,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = NULL,
+#endif
+	.port_get_raw = gpio_siwx917_uulp_port_get,
+	.port_set_masked_raw = gpio_siwx917_uulp_port_set_masked,
+	.port_set_bits_raw = gpio_siwx917_uulp_port_set_bits,
+	.port_clear_bits_raw = gpio_siwx917_uulp_port_clear_bits,
+	.port_toggle_bits = gpio_siwx917_uulp_port_toggle_bits,
+	.pin_interrupt_configure = gpio_siwx917_uulp_interrupt_configure,
+	.manage_callback = gpio_siwx917_uulp_manage_callback,
+	.get_pending_int = NULL,
+#ifdef CONFIG_GPIO_GET_DIRECTION
+	.port_get_direction = NULL,
+#endif
+};
+
+#define GPIO_PORT_INIT(idx)                                                                        \
+	static int gpio_siwx917_init_uulp_##idx##_(const struct device *dev);                      \
+	static const struct gpio_siwx917_uulp_config gpio_siwx917_port_##idx##_config = {          \
+		.common =                                                                          \
+			{                                                                          \
+				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(idx),             \
+			},                                                                         \
+	};                                                                                         \
+	static struct gpio_siwx917_uulp_data gpio_siwx917_port_##idx##_data;                       \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(idx, gpio_siwx917_init_uulp_##idx##_, NULL,                          \
+			      &gpio_siwx917_port_##idx##_data, &gpio_siwx917_port_##idx##_config,  \
+			      PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,                             \
+			      &gpio_siwx917_uulp_driver_api);                                      \
+	static int gpio_siwx917_init_uulp_##idx##_(const struct device *dev)                       \
+	{                                                                                          \
+		sys_write32(0, DT_INST_REG_ADDR_BY_NAME(idx, int) + UULP_REG_INTERRUPT_CONFIG);    \
+		IRQ_CONNECT(DT_INST_IRQ(idx, irq), DT_INST_IRQ(idx, priority),                     \
+			    gpio_siwx917_uulp_isr, DEVICE_DT_GET(DT_DRV_INST(idx)), 0);            \
+		irq_enable(DT_INST_IRQ(idx, irq));                                                 \
+		return 0;                                                                          \
+	}
+
+DT_INST_FOREACH_STATUS_OKAY(GPIO_PORT_INIT)

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -59,6 +59,104 @@
 			current-speed = <115200>;
 			status = "disabled";
 		};
+
+		egpio0: egpio@46130000 {
+			compatible = "silabs,siwx917-gpio";
+			reg = <0x46130000 0x1260>;
+			interrupts = <52 0>, <53 0>, <54 0>, <55 0>,
+				     <56 0>, <57 0>, <58 0>, <59 0>;
+			interrupt-names = "PIN0", "PIN1", "PIN2", "PIN3",
+					  "PIN4", "PIN5", "PIN6", "PIN7";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			gpioa: gpio@0 {
+				compatible = "silabs,siwx917-gpio-port";
+				reg = <0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+				gpio-reserved-ranges = <0 6>;
+				silabs,pads = [
+					ff ff ff ff  ff ff 01 02  03 04 05 06  07 ff ff 08
+				];
+				status = "okay";
+			};
+
+			gpiob: gpio@1 {
+				compatible = "silabs,siwx917-gpio-port";
+				reg = <1>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+				silabs,pads = [
+					ff ff ff ff  ff ff ff ff  ff 00 00 00  00 00 00 09
+				];
+				status = "okay";
+			};
+
+			gpioc: gpio@2 {
+				compatible = "silabs,siwx917-gpio-port";
+				reg = <2>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+				silabs,pads = [
+					09 09 09 ff  ff ff ff ff  ff ff ff ff  ff ff 0a 0b
+				];
+				status = "okay";
+			};
+
+			gpiod: gpio@3 {
+				compatible = "silabs,siwx917-gpio-port";
+				reg = <3>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <10>;
+				silabs,pads = [
+					0c 0d 0e 0f  10 11 12 13  14 15 ff ff  ff ff ff ff
+				];
+				status = "okay";
+			};
+		};
+
+		egpio1: egpio@2404c000 {
+			compatible = "silabs,siwx917-gpio";
+			reg = <0x2404C000 0x1260>;
+			interrupts = <18 0>;
+			interrupt-names = "ULP";
+			silabs,ulp;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ulpgpio: ulpgpio@0 {
+				compatible = "silabs,siwx917-gpio-port";
+				reg = <0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <12>;
+				gpio-reserved-ranges = <3 1>;
+				silabs,pads = [
+					16 17 18 19  1a 1b 1c 1d  1e 1f 20 21  ff ff ff ff
+				];
+				status = "okay";
+			};
+		};
+
+		uulpgpio: uulpgpio@24048600 {
+			compatible = "silabs,siwx917-gpio-uulp";
+			reg = <0x24048600 0x30>, <0x12080000 0x18>;
+			reg-names = "ret", "int";
+			interrupts = <21 0>;
+			interrupt-names = "UULP";
+
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <5>;
+			status = "okay";
+		};
 	};
 };
 

--- a/dts/bindings/gpio/silabs,siwx917-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,siwx917-gpio-port.yaml
@@ -1,0 +1,25 @@
+description: Silabs SiWx917 GPIO port node
+
+compatible: "silabs,siwx917-gpio-port"
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+
+  reg:
+    required: true
+
+  "#gpio-cells":
+    const: 2
+
+  silabs,pads:
+    type: uint8-array
+    required: true
+    description: |
+      Contains the map of what pad number is used for each GPIO.
+      0xFF if a GPIO has no pad.
+      0 if the pad is directly configured using port and pin number.
+
+gpio-cells:
+  - pin
+  - flags

--- a/dts/bindings/gpio/silabs,siwx917-gpio-uulp.yaml
+++ b/dts/bindings/gpio/silabs,siwx917-gpio-uulp.yaml
@@ -1,0 +1,17 @@
+description: Silabs SiWx917 UULP (ultra ultra low power) GPIO port node
+
+compatible: "silabs,siwx917-gpio-uulp"
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+
+  reg:
+    required: true
+
+  "#gpio-cells":
+    const: 2
+
+gpio-cells:
+  - pin
+  - flags

--- a/dts/bindings/gpio/silabs,siwx917-gpio.yaml
+++ b/dts/bindings/gpio/silabs,siwx917-gpio.yaml
@@ -1,0 +1,17 @@
+description: Silabs SiWx917 GPIO node
+
+compatible: "silabs,siwx917-gpio"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  silabs,ulp:
+    type: boolean
+    description: |
+      If this property is set, the GPIO controller uses ULP (ultra low power) pads.

--- a/tests/drivers/gpio/gpio_basic_api/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/siwx917_rb4338a.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		/* GPIO HP */
+		out-gpios = <&gpiod 0 0>; /* WPK P28 */
+		in-gpios = <&gpiod 2 0>; /* WPK P32 */
+		/* GPIO UULP */
+		// out-gpios = <&uulpgpio 0 0>; /* WPK P14 */
+		// in-gpios = <&uulpgpio 3 0>; /* WPK P18 */
+	};
+};

--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
   projects:
     - name: hal_silabs
       remote: silabs
-      revision: d3191b380c5a0975230881bcf21045e92189c263
+      revision: 51ffe2b8174529c7fd1bed54383855a7e2988f55
       path: modules/hal/silabs
     - name: zephyr
       remote: zephyrproject-rtos


### PR DESCRIPTION
Implement GPIO driver for HP, ULP and UULP GPIOs.

This PR enables GPIO, and implements functional interrupt handling for all 3 GPIO modules.

TODO:

- [ ] Resolve duplicate node address between pinctrl and gpio
- [x] Consider defining ULP and UULP ports outside GPIO node in DT, as they have separate addresses in reality
- [ ] Consider moving port number from `reg` to `peripheral-id`
- [x] Advanced GPIO modes (pullup/down etc)
- [x] Bottom out NVIC priority definition (4 vs 6 levels)
- [x] Consider moving common init to a higher priority than port init (or is it OK for them to be the same?)

Inputs are very welcome on the above points.