### PR TITLE
soc: silabs: siwg917: Include correct device header

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -63,5 +63,5 @@
 };
 
 &nvic {
-	arm,num-irq-priority-bits = <4>;
+	arm,num-irq-priority-bits = <6>;
 };

--- a/soc/silabs/silabs_siwx917/siwg917/soc.h
+++ b/soc/silabs/silabs_siwx917/siwg917/soc.h
@@ -5,6 +5,6 @@
 #ifndef SIWG917_SOC_H
 #define SIWG917_SOC_H
 
-#include "RS1xxxx.h"
+#include "si91x_device.h"
 
 #endif


### PR DESCRIPTION
Include si91x_device.h from soc.h. This is the device header used by the Wiseconnect HAL. The legacy RS1xxx.h header differs in subtle ways.

This PR fixes an inconsistency in the definition of __NVIC_PRIO_BITS between Zephyr and the Wiseconnect HAL leading to compiler errors when using certain HAL functions (#include-ing both Zephyr and Wiseconnect headers in the same file).