### PR TITLE
soc: silabs: siwx917: Enable I2C

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
@@ -9,6 +9,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input-event-codes.h>
 #include <dt-bindings/pinctrl/silabs/siwx917-pinctrl.h>
+#include <common/freq.h>
 
 / {
 	model = "Silicon Labs BRD4338A (SiWG917 Radio Board)";
@@ -58,6 +59,19 @@
 	pinctrl-names = "default";
 };
 
+&ulpi2c {
+	status = "disabled";
+	pinctrl-0 = <&ulpi2c_default>;
+	pinctrl-names = "default";
+	clock-frequency = <DT_FREQ_K(100)>;
+
+	si7021: si7021@40 {
+		compatible = "silabs,si7006";
+		reg = <0x40>;
+		status = "disabled";
+	};
+};
+
 &pinctrl0 {
 	ulpuart0_default: ulpuart0_default {
 		out {
@@ -65,6 +79,11 @@
 		};
 		in {
 			pinmux = <ULPUART_RX_ULP9>;
+		};
+	};
+	ulpi2c_default: ulpi2c_default {
+		group {
+			pinmux = <ULPI2C_SDA_ULP6>, <ULPI2C_SCL_ULP7>;
 		};
 	};
 };

--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.yaml
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.yaml
@@ -10,4 +10,5 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - i2c
 vendor: silabs

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -167,6 +167,36 @@
 			ngpios = <5>;
 			status = "okay";
 		};
+
+		i2c0: i2c@44010000 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44010000 0x100>;
+			interrupts = <42 0>;
+			interrupt-names = "i2c0";
+			status = "disabled";
+		};
+
+		i2c1: i2c@47040000 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x47040000 0x100>;
+			interrupts = <61 0>;
+			interrupt-names = "i2c1";
+			status = "disabled";
+		};
+
+		ulpi2c: i2c@24040000 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x24040000 0x100>;
+			interrupts = <13 0>;
+			interrupt-names = "i2c2";
+			status = "disabled";
+		};
 	};
 };
 

--- a/soc/silabs/silabs_siwx917/siwg917/soc.c
+++ b/soc/silabs/silabs_siwx917/siwg917/soc.c
@@ -35,6 +35,18 @@ int silabs_siwx917_init(void)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart2), okay)
 	RSI_CLK_UsartClkConfig(M4CLK, ENABLE_STATIC_CLK, 0, USART2, 0, 1);
 #endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c0), okay)
+	RSI_PS_M4ssPeriPowerUp(M4SS_PWRGATE_ULP_EFUSE_PERI);
+	RSI_CLK_I2CClkConfig(M4CLK, true, 0);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c1), okay)
+	RSI_PS_M4ssPeriPowerUp(M4SS_PWRGATE_ULP_EFUSE_PERI);
+	RSI_CLK_I2CClkConfig(M4CLK, true, 1);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ulpi2c), okay)
+	RSI_PS_UlpssPeriPowerUp(ULPSS_PWRGATE_ULP_I2C);
+	RSI_ULPSS_PeripheralEnable(ULPCLK, ULP_I2C_CLK, ENABLE_STATIC_CLK);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Add snps,designware-i2c compatibility for I2C peripherals.  
Enable I2C clocks in soc.c for now, pending proper implementation of clock control.  
Add pinctrl configuration for Si7021 sensor on rb4338a board.