### PR TITLE
soc: silabs: siwx917: Define flash mode in Kconfig file

### DIFF
--- a/soc/silabs/silabs_siwx917/siwg917/Kconfig
+++ b/soc/silabs/silabs_siwx917/siwg917/Kconfig
@@ -3,3 +3,15 @@
 
 config SOC_SERIES_SIWG917
 	select SOC_FAMILY_SILABS_SIWX917
+
+choice SIWX917_FLASH_MODE
+	bool "Flash Mode"
+	default SIWX917_FLASH_MODE_COMMON
+
+config SIWX917_FLASH_MODE_COMMON
+	bool "Common Flash"
+
+config SIWX917_FLASH_MODE_DUAL
+	bool "Dual Flash"
+
+endchoice

--- a/soc/silabs/silabs_siwx917/siwg917/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx917/siwg917/Kconfig.defconfig
@@ -10,16 +10,4 @@ config FLASH_BASE_ADDRESS
 config NUM_IRQS
 	default 99
 
-choice SIWX917_FLASH_MODE
-	bool "Flash Mode"
-	default SIWX917_FLASH_MODE_COMMON
-
-config SIWX917_FLASH_MODE_COMMON
-	bool "Common Flash"
-
-config SIWX917_FLASH_MODE_DUAL
-	bool "Dual Flash"
-
-endchoice
-
 endif


### PR DESCRIPTION
Does not belong in defconfig.