### PR TITLE
drivers: siwx917_wifi: Update net_context state

### DIFF
--- a/drivers/wifi/siwx917/siwx917_wifi.c
+++ b/drivers/wifi/siwx917/siwx917_wifi.c
@@ -458,6 +458,7 @@ static int siwx917_sock_connect(struct net_context *context,
 	SL_SI91X_FD_SET(sockfd, &sidev->fds_watch);
 	sl_si91x_select(NUMBER_OF_BSD_SOCKETS, &sidev->fds_watch, NULL, NULL, NULL,
 			siwx917_sock_on_recv);
+	net_context_set_state(context, NET_CONTEXT_CONNECTED);
 	if (cb) {
 		cb(context, ret, user_data);
 	}
@@ -473,6 +474,7 @@ static int siwx917_sock_listen(struct net_context *context, int backlog)
 	if (ret) {
 		return -errno;
 	}
+	net_context_set_state(context, NET_CONTEXT_LISTENING);
 	return 0;
 }
 


### PR DESCRIPTION
The Zephyr stack does not update net_context state when CONFIG_NET_OFFLOAD=y. However, this field is still used in some not-offloaded operations (eg. poll()).

So, update net_context state manually.

Reported-by: Tibor Laczko <tibor.laczko@silabs.com>