### PR TITLE
github: workflows: Add a Do Not Merge workflow

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -1,0 +1,17 @@
+name: Do Not Merge
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}
+    name: Prevent Merging
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'DNM'."
+          echo "This workflow fails so that the pull request cannot be merged."
+          exit 1


### PR DESCRIPTION
This allows us to fail CI if a DNM label is set. It's also preparation for a manifest workflow which can set the label automatically when the manifest points at a pull request rather than an actual commit in a module.