### PR TITLE
manifest: Fix HAL revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
   projects:
     - name: hal_silabs
       remote: silabs
-      revision: pull/9/head
+      revision: 2eb82930b376900f1b6949e218199ab33ba6f34c
       path: modules/hal/silabs
     - name: zephyr
       remote: zephyrproject-rtos


### PR DESCRIPTION
Commit 99b1b03 ("manifest: Update Zephyr and HAL revisions") depended on a PR on hal_silabs. Unfortunately, it has been merged without updating the occurrence to this repo.

Fixes: 99b1b03 ("manifest: Update Zephyr and HAL revisions")