### PR TITLE
CODEOWNERS: Fix user references

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       jhedberg asmellby jerome-pouiller
+*       @jhedberg @asmellby @jerome-pouiller


### PR DESCRIPTION
The usernames were missing the @ character.