### PR TITLE
manifest: Update to latest upstream version

### DIFF
--- a/dts/bindings/bluetooth/silabs,bt-hci-siwx917.yaml
+++ b/dts/bindings/bluetooth/silabs,bt-hci-siwx917.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "sl:bt:siwx917"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_RESET"]
+    default: ["no-reset"]

--- a/west.yml
+++ b/west.yml
@@ -15,7 +15,7 @@ manifest:
       path: modules/hal/silabs
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: 1ec5ce05f9f84b18cb8056d01917480a6ec39e52
+      revision: a2ac676a106a757fe4cb2664bab35ea985da95f9
       import:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.


### PR DESCRIPTION
This update requires updating the siwx917 Bluetooth HCI devicetree binding as well, since the format for bt-hci-bus and bt-hci-quirks properties has changed.