### PR TITLE
soc: silabs: siwg917: Device needs .hex firmware

### DIFF
--- a/soc/silabs/silabs_siwx917/siwg917/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx917/siwg917/Kconfig.defconfig
@@ -10,4 +10,7 @@ config FLASH_BASE_ADDRESS
 config NUM_IRQS
 	default 99
 
+config BUILD_OUTPUT_HEX
+	default y
+
 endif


### PR DESCRIPTION
Commit a448c72 ("soc: silabs: siwg917: Get rid of siwx917_isp_prepare.py") allows to flash the device using the .hex file. However, the .hex file was not build by default.

Fixes: a448c72 "soc: silabs: siwg917: Get rid of siwx917_isp_prepare.py"