### PR TITLE
manifest: Update HAL revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
   projects:
     - name: hal_silabs
       remote: silabs
-      revision: ca720524a33c4bb55446ceb7e94502e37153d941
+      revision: pull/8/head
       path: modules/hal/silabs
     - name: zephyr
       remote: zephyrproject-rtos


### PR DESCRIPTION
This version of hal_silabs allows to compile WiseConnect without the support for socket offloading when it is not needed.