### PR TITLE
README: Add status badge for upstream daily build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Silabs upstream daily build][badge]][recipe]
+
+[badge]:  https://github.com/SiliconLabsSoftware/zephyr-silabs/actions/workflows/upstream-build.yml/badge.svg
+[recipe]: https://github.com/SiliconLabsSoftware/zephyr-silabs/actions/workflows/upstream-build.yml
+
 Silicon Labs Zephyr repository
 ==============================
 


### PR DESCRIPTION
Add a status badge to indicate whether the upstream daily build is passing or not.