### PR TITLE
drivers: bluetooth: siwx917: Fix missing ENTROPY_GENERATOR selection

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.siwx917
+++ b/drivers/bluetooth/hci/Kconfig.siwx917
@@ -6,5 +6,6 @@ config BT_SIWX917
 	default y
 	depends on DT_HAS_SILABS_BT_HCI_SIWX917_ENABLED
 	select WISECONNECT_NETWORK_STACK
+	select ENTROPY_GENERATOR
 	help
 	  Use Silicon Labs Wiseconnect 3.x Bluetooth library to connect to the controller.


### PR DESCRIPTION
With a recent upstream change related to removing TinyCrypt support, the HCI drivers need to make sure the top-level entropy driver option is enabled.