### PR TITLE
github: workflows: Add a Bluetooth observer test case

### DIFF
--- a/.github/workflows/upstream-build.yml
+++ b/.github/workflows/upstream-build.yml
@@ -59,8 +59,11 @@ jobs:
         working-directory: zephyr-silabs
         shell: bash
         run: |
-          west twister -s sample.bluetooth.peripheral_hr -p xg27_dk2602a -v --inline-logs -K
-          west twister -s sample.bluetooth.peripheral_hr -p siwx917_rb4338a -v --inline-logs -K
+          west twister -v --inline-logs -K \
+            -p xg27_dk2602a \
+            -p siwx917_rb4338a \
+            -s sample.bluetooth.peripheral_hr \
+            -s sample.bluetooth.observer
 
       - name: Build Rail samples
         working-directory: zephyr-silabs


### PR DESCRIPTION
Add a new Bluetooth Observer role test case, and at the same time consolidate the various test & platform options into a single twister invocation. The observer test is useful since it doesn't enable SMP, and would have helped catch a regression for EFR32 platforms.

https://github.com/zephyrproject-rtos/zephyr/issues/82569
https://github.com/zephyrproject-rtos/zephyr/pull/82575