### PR TITLE
CODEOWNERS: Update to use the new maintainers team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @jhedberg @asmellby @jerome-pouiller @martinhoff-maker
+*       @SiliconLabsSoftware/zephyr-maintainers


### PR DESCRIPTION
There's now a dedicated Zephyr maintainers team, so use that.