### PR TITLE
github: workflows: Align build.yml with upstream-build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: zephyr-silabs
         shell: bash
         run: |
-          west twister -v --inline-logs \
+          west twister -v --inline-logs -K \
             -s drivers.entropy \
             -p siwx917_rb4338a
 
@@ -71,6 +71,7 @@ jobs:
         run: |
           west twister -v --inline-logs -K \
             -s sample.bluetooth.peripheral_hr \
+            -s sample.bluetooth.observer \
             -p siwx917_rb4338a
 
       - name: Build Rail samples


### PR DESCRIPTION
Commit 2208911 ("github: workflows: Add a Bluetooth observer test case") adds a new test to the nightly CI.

This patch tries to keep build.yml and upstream-build.yml in sync.