### PR TITLE
drivers: wifi: siwx917: Add support for advanced scan options

### DIFF
--- a/drivers/wifi/siwx917/Kconfig.siwx917
+++ b/drivers/wifi/siwx917/Kconfig.siwx917
@@ -44,4 +44,9 @@ config NET_MGMT_EVENT_STACK_SIZE
 config NET_MGMT_EVENT_QUEUE_SIZE
 	default 10
 
+# Override the WIFI_MGMT_SCAN_SSID_FILT_MAX parameter for the Wi-Fi subsystem.
+# This device supports filtering scan results for only one SSID.
+config WIFI_MGMT_SCAN_SSID_FILT_MAX
+	default 1
+
 endif

--- a/drivers/wifi/siwx917/siwx917_wifi.c
+++ b/drivers/wifi/siwx917/siwx917_wifi.c
@@ -198,6 +198,7 @@ static int siwx917_scan(const struct device *dev, struct wifi_scan_params *z_sca
 {
 	sl_wifi_scan_configuration_t sl_scan_config = { };
 	struct siwx917_dev *sidev = dev->data;
+	sl_wifi_ssid_t ssid = {};
 	int ret;
 
 	__ASSERT(z_scan_config, "z_scan_config cannot be NULL");
@@ -211,9 +212,16 @@ static int siwx917_scan(const struct device *dev, struct wifi_scan_params *z_sca
 
 	sl_scan_config.channel_bitmap_2g4 = 0xFFFF;
 	memset(sl_scan_config.channel_bitmap_5g, 0xFF, sizeof(sl_scan_config.channel_bitmap_5g));
+	if (IS_ENABLED(CONFIG_WIFI_MGMT_SCAN_SSID_FILT_MAX)) {
+		if (z_scan_config->ssids[0]) {
+			strncpy(ssid.value, z_scan_config->ssids[0], WIFI_SSID_MAX_LEN);
+			ssid.length = strlen(z_scan_config->ssids[0]);
+		}
+	}
 
 	sidev->scan_res_cb = cb;
-	ret = sl_wifi_start_scan(SL_WIFI_CLIENT_INTERFACE, NULL, &sl_scan_config);
+	ret = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, (ssid.length > 0) ? &ssid : NULL,
+				 &sl_scan_config);
 	if (ret != SL_STATUS_IN_PROGRESS) {
 		return -EIO;
 	}

--- a/drivers/wifi/siwx917/siwx917_wifi.c
+++ b/drivers/wifi/siwx917/siwx917_wifi.c
@@ -180,12 +180,19 @@ static unsigned int siwx917_on_scan(sl_wifi_event_t event, sl_wifi_scan_result_t
 				    uint32_t result_size, void *arg)
 {
 	struct siwx917_dev *sidev = arg;
-	int i;
+	int i, scan_count;
 
 	if (!sidev->scan_res_cb) {
 		return -EFAULT;
 	}
-	for (i = 0; i < result->scan_count; i++) {
+
+	if (sidev->scan_max_bss_cnt) {
+		scan_count = MIN(result->scan_count, sidev->scan_max_bss_cnt);
+	} else {
+		scan_count = result->scan_count;
+	}
+
+	for (i = 0; i < scan_count; i++) {
 		siwx917_report_scan_res(sidev, result, i);
 	}
 	sidev->scan_res_cb(sidev->iface, 0, NULL);
@@ -219,6 +226,7 @@ static int siwx917_scan(const struct device *dev, struct wifi_scan_params *z_sca
 		}
 	}
 
+	sidev->scan_max_bss_cnt = z_scan_config->max_bss_cnt;
 	sidev->scan_res_cb = cb;
 	ret = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, (ssid.length > 0) ? &ssid : NULL,
 				 &sl_scan_config);

--- a/drivers/wifi/siwx917/siwx917_wifi.c
+++ b/drivers/wifi/siwx917/siwx917_wifi.c
@@ -155,6 +155,7 @@ static void siwx917_report_scan_res(struct siwx917_dev *sidev, sl_wifi_scan_resu
 		{ SL_WIFI_WPA_ENTERPRISE,  WIFI_SECURITY_TYPE_EAP     },
 		{ SL_WIFI_WPA2_ENTERPRISE, WIFI_SECURITY_TYPE_EAP     },
 	};
+
 	struct wifi_scan_result tmp = {
 		.channel = result->scan_info[item].rf_channel,
 		.rssi = result->scan_info[item].rssi_val,
@@ -162,17 +163,28 @@ static void siwx917_report_scan_res(struct siwx917_dev *sidev, sl_wifi_scan_resu
 		.mac_length = sizeof(result->scan_info[item].bssid),
 		.security = WIFI_SECURITY_TYPE_UNKNOWN,
 		.mfp = WIFI_MFP_UNKNOWN,
-		/* FIXME: fill .mfp, .band and .channel */
+		.band = WIFI_FREQ_BAND_2_4_GHZ,
 	};
 	int i;
 
+	if (result->scan_count == 0) {
+		return;
+	}
+
+	if (result->scan_info[item].rf_channel <= 0 || result->scan_info[item].rf_channel > 14) {
+		LOG_WRN("Unexpected scan result");
+		tmp.band = WIFI_FREQ_BAND_UNKNOWN;
+	}
+
 	memcpy(tmp.ssid, result->scan_info[item].ssid, tmp.ssid_length);
 	memcpy(tmp.mac, result->scan_info[item].bssid, tmp.mac_length);
+
 	for (i = 0; i < ARRAY_SIZE(security_convert); i++) {
 		if (security_convert[i].sl_val == result->scan_info[item].security_mode) {
 			tmp.security = security_convert[i].z_val;
 		}
 	}
+
 	sidev->scan_res_cb(sidev->iface, 0, &tmp);
 }
 
@@ -186,6 +198,10 @@ static unsigned int siwx917_on_scan(sl_wifi_event_t event, sl_wifi_scan_result_t
 		return -EFAULT;
 	}
 
+	if (event & SL_WIFI_EVENT_FAIL_INDICATION) {
+		memset(result, 0, sizeof(*result));
+	}
+
 	if (sidev->scan_max_bss_cnt) {
 		scan_count = MIN(result->scan_count, sidev->scan_max_bss_cnt);
 	} else {
@@ -195,8 +211,10 @@ static unsigned int siwx917_on_scan(sl_wifi_event_t event, sl_wifi_scan_result_t
 	for (i = 0; i < scan_count; i++) {
 		siwx917_report_scan_res(sidev, result, i);
 	}
+
 	sidev->scan_res_cb(sidev->iface, 0, NULL);
 	sidev->state = WIFI_STATE_INACTIVE;
+
 	return 0;
 }
 
@@ -217,7 +235,10 @@ static int siwx917_scan(const struct device *dev, struct wifi_scan_params *z_sca
 	/* The enum values are same, no conversion needed */
 	sl_scan_config.type = z_scan_config->scan_type;
 
-	sl_scan_config.channel_bitmap_2g4 = 0xFFFF;
+	for (int i = 0; i < WIFI_MGMT_SCAN_CHAN_MAX_MANUAL; i++) {
+		sl_scan_config.channel_bitmap_2g4 |= BIT(z_scan_config->band_chan[i].channel - 1);
+	}
+
 	memset(sl_scan_config.channel_bitmap_5g, 0xFF, sizeof(sl_scan_config.channel_bitmap_5g));
 	if (IS_ENABLED(CONFIG_WIFI_MGMT_SCAN_SSID_FILT_MAX)) {
 		if (z_scan_config->ssids[0]) {

--- a/drivers/wifi/siwx917/siwx917_wifi.c
+++ b/drivers/wifi/siwx917/siwx917_wifi.c
@@ -232,8 +232,27 @@ static int siwx917_scan(const struct device *dev, struct wifi_scan_params *z_sca
 		return -EBUSY;
 	}
 
-	/* The enum values are same, no conversion needed */
-	sl_scan_config.type = z_scan_config->scan_type;
+	if (z_scan_config->scan_type == WIFI_SCAN_TYPE_ACTIVE) {
+		sl_scan_config.type = SL_WIFI_SCAN_TYPE_ACTIVE;
+		if (!z_scan_config->dwell_time_active) {
+			ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_ACTIVE_SCAN_TIMEOUT,
+							 SL_WIFI_DEFAULT_ACTIVE_CHANNEL_SCAN_TIME);
+		} else {
+			ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_ACTIVE_SCAN_TIMEOUT,
+							 z_scan_config->dwell_time_active);
+		}
+
+		if (ret) {
+			return -EINVAL;
+		}
+	} else {
+		sl_scan_config.type = SL_WIFI_SCAN_TYPE_PASSIVE;
+		ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_PASSIVE_SCAN_TIMEOUT,
+						 z_scan_config->dwell_time_passive);
+		if (ret) {
+			return -EINVAL;
+		}
+	}
 
 	for (int i = 0; i < WIFI_MGMT_SCAN_CHAN_MAX_MANUAL; i++) {
 		sl_scan_config.channel_bitmap_2g4 |= BIT(z_scan_config->band_chan[i].channel - 1);

--- a/drivers/wifi/siwx917/siwx917_wifi.h
+++ b/drivers/wifi/siwx917/siwx917_wifi.h
@@ -19,6 +19,7 @@ struct siwx917_dev {
 	sl_mac_address_t macaddr;
 	enum wifi_iface_state state;
 	scan_result_cb_t scan_res_cb;
+	uint16_t scan_max_bss_cnt;
 
 #ifdef CONFIG_WIFI_SIWX917_NET_STACK_OFFLOAD
 	struct k_event fds_recv_event;


### PR DESCRIPTION
This commit adds support for the following scan functionalities

- Single and multi-channel scan
- Direct SSID scan
- Dwell time configuration for both active and passive scans
- Maximum BSS count configuration for the 2.4 GHz band

Since the device operates solely on the 2.4 GHz frequency band, this enhancement enables it to send probe requests and listen for beacon frames on specified channels, improving scan efficiency and customization.