### PR TITLE
Add AP mode support and error propagation improvements

### DIFF
--- a/drivers/wifi/siwx917/siwx917_wifi.c
+++ b/drivers/wifi/siwx917/siwx917_wifi.c
@@ -298,13 +298,78 @@ static int siwx917_scan(const struct device *dev, struct wifi_scan_params *z_sca
 static int siwx917_status(const struct device *dev, struct wifi_iface_status *status)
 {
 	struct siwx917_dev *sidev = dev->data;
+	sl_si91x_rsp_wireless_info_t wlan_info = { };
+	int ret;
 	int32_t rssi = -1;
+
+	__ASSERT(status, "status cannot be NULL");
 
 	memset(status, 0, sizeof(*status));
 	status->state = sidev->state;
-	sl_wifi_get_signal_strength(SL_WIFI_CLIENT_INTERFACE, &rssi);
-	status->rssi = rssi;
-	return 0;
+
+	ret = sl_wifi_get_wireless_info(&wlan_info);
+	if (ret) {
+		LOG_ERR("Failed to get the wireless info: 0x%x", ret);
+		return -EIO;
+	}
+
+	strncpy(status->ssid, wlan_info.ssid, WIFI_SSID_MAX_LEN);
+	status->ssid_len = strlen(status->ssid);
+	memcpy(status->bssid, wlan_info.mac_address, WIFI_MAC_ADDR_LEN);
+	status->mfp = WIFI_MFP_REQUIRED;
+
+	if (FIELD_GET(SL_WIFI_2_4GHZ_INTERFACE, sidev->interface)) {
+		status->band = WIFI_FREQ_BAND_2_4_GHZ;
+	}
+
+	if (FIELD_GET(SL_WIFI_CLIENT_INTERFACE, sidev->interface)) {
+		sl_wifi_listen_interval_t listen_interval = { };
+
+		status->link_mode = WIFI_LINK_MODE_UNKNOWN;
+		status->iface_mode = WIFI_MODE_INFRA;
+		status->channel = wlan_info.channel_number;
+		sl_wifi_get_signal_strength(SL_WIFI_CLIENT_INTERFACE, &rssi);
+		status->rssi = rssi;
+
+		sl_wifi_get_listen_interval(SL_WIFI_CLIENT_INTERFACE, &listen_interval);
+		status->beacon_interval = listen_interval.listen_interval;
+	} else if (FIELD_GET(SL_WIFI_AP_INTERFACE, sidev->interface)) {
+		sl_wifi_ap_configuration_t conf = { };
+
+		ret = sl_wifi_get_ap_configuration(SL_WIFI_AP_INTERFACE, &conf);
+		if (ret) {
+			LOG_ERR("Failed to get the AP configuration: 0x%x", ret);
+			return -EINVAL;
+		}
+
+		status->link_mode = WIFI_4;
+		status->iface_mode = WIFI_MODE_AP;
+		status->channel = conf.channel.channel;
+		status->beacon_interval = conf.beacon_interval;
+		status->dtim_period = conf.dtim_beacon_count;
+	} else {
+		status->link_mode = WIFI_LINK_MODE_UNKNOWN;
+		status->iface_mode = WIFI_MODE_UNKNOWN;
+		status->channel = 0;
+
+		return -EINVAL;
+	}
+
+	switch (wlan_info.sec_type) {
+	case SL_WIFI_OPEN:
+		status->security = WIFI_SECURITY_TYPE_NONE;
+		break;
+	case SL_WIFI_WPA2:
+		status->security = WIFI_SECURITY_TYPE_PSK;
+		break;
+	case SL_WIFI_WPA3:
+		status->security = WIFI_SECURITY_TYPE_SAE;
+		break;
+	default:
+		status->security = WIFI_SECURITY_TYPE_UNKNOWN;
+	}
+
+	return ret;
 }
 
 #ifdef CONFIG_WIFI_SIWX917_NET_STACK_NATIVE
@@ -545,6 +610,34 @@ static sl_status_t siwx917_on_disconnect(sl_wifi_event_t event, void *data,
 	return SL_STATUS_OK;
 }
 
+#if defined(CONFIG_NET_STATISTICS_WIFI)
+static int siwx917_stats(const struct device *dev, struct net_stats_wifi *stats)
+{
+	struct siwx917_dev *sidev = dev->data;
+	sl_wifi_statistics_t statistics = { };
+	int ret;
+
+	__ASSERT(stats, "stats cannot be NULL");
+
+	ret = sl_wifi_get_statistics(FIELD_GET(SIWX917_INTERFACE_MASK, sidev->interface),
+					&statistics);
+	if (ret) {
+		LOG_ERR("Failed to get stat: 0x%x", ret);
+		return -EINVAL;
+	}
+
+	stats->multicast.rx = statistics.mcast_rx_count;
+	stats->multicast.tx = statistics.mcast_tx_count;
+	stats->unicast.rx = statistics.ucast_rx_count;
+	stats->unicast.tx = statistics.ucast_tx_count;
+	stats->sta_mgmt.beacons_rx = statistics.beacon_rx_count;
+	stats->sta_mgmt.beacons_miss = statistics.beacon_lost_count;
+	stats->overrun_count = statistics.overrun_count;
+
+	return ret;
+}
+#endif
+
 static void siwx917_iface_init(struct net_if *iface)
 {
 	struct siwx917_dev *sidev = iface->if_dev->dev->data;
@@ -588,6 +681,9 @@ static const struct wifi_mgmt_ops siwx917_mgmt = {
 	.ap_disable   = siwx917_ap_disable,
 	.ap_sta_disconnect = siwx917_ap_sta_disconnect,
 	.iface_status = siwx917_status,
+#if defined(CONFIG_NET_STATISTICS_WIFI)
+	.get_stats = siwx917_stats,
+#endif
 };
 
 static const struct net_wifi_mgmt_offload siwx917_api = {

--- a/drivers/wifi/siwx917/siwx917_wifi.h
+++ b/drivers/wifi/siwx917/siwx917_wifi.h
@@ -14,9 +14,12 @@
 #include "sl_si91x_socket_types.h"
 #include "sl_si91x_protocol_types.h"
 
+#define SIWX917_INTERFACE_MASK (0x03)
+
 struct siwx917_dev {
 	struct net_if *iface;
 	sl_mac_address_t macaddr;
+	sl_wifi_interface_t interface;
 	enum wifi_iface_state state;
 	scan_result_cb_t scan_res_cb;
 	uint16_t scan_max_bss_cnt;


### PR DESCRIPTION
This PR adds AP mode support to the siwx917 Wi-Fi driver, enabling commands to manage the AP and connected stations. It also introduces error handling to map WiseConnect SDK error codes to corresponding Zephyr error codes, ensuring consistent and meaningful error reporting.