### PR TITLE
drivers: bluetooth: siwx917: Temporarily fixes the SMP issues

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.siwx917
+++ b/drivers/bluetooth/hci/Kconfig.siwx917
@@ -9,3 +9,7 @@ config BT_SIWX917
 	select ENTROPY_GENERATOR
 	help
 	  Use Silicon Labs Wiseconnect 3.x Bluetooth library to connect to the controller.
+
+# SiWx917 BLE controller currently does not support HCI Command: Host Number of Completed Packets
+configdefault BT_HCI_ACL_FLOW_CONTROL
+	default n if BT_SIWX917


### PR DESCRIPTION
The SiWx917 BLE controller currently does not support HCI Command 0x0C35 i.e. Host Number of Completed Packets Command Disabling the ACL Flow Control avoids sending this command during SMP Pairing process and therefore avoiding an ASSERT