### PR TITLE
manifest: Update hal_silabs and zephyr to latest upstream versions

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
   projects:
     - name: hal_silabs
       remote: silabs
-      revision: 2ad0fd7d56a9142a0479f5745277fda8b21da0db
+      revision: 9d32354344f6c816410e2642c2f81677f8a60e96
       path: modules/hal/silabs
     - name: zephyr-mbedtls
       remote: silabs
@@ -19,7 +19,7 @@ manifest:
       path: modules/crypto/mbedtls
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: 0b843be90d5e42432c1fb035a8d036276b626e08
+      revision: b80526658cc0e6ec5719f09cd8fff65d4e50525c
       import:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.


### PR DESCRIPTION
The nightly upstream build just started failing because of stuff that's been merged in the latest upstream hal_silabs. Update that reference, and also update the Zephyr main tree in the same go.