### PR TITLE
manifest: Update to latest upstream revisions

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
   projects:
     - name: hal_silabs
       remote: silabs
-      revision: 9d32354344f6c816410e2642c2f81677f8a60e96
+      revision: 40a0237e4812241de677441e02131d6c75830636
       path: modules/hal/silabs
     - name: zephyr-mbedtls
       remote: silabs
@@ -19,7 +19,7 @@ manifest:
       path: modules/crypto/mbedtls
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: b80526658cc0e6ec5719f09cd8fff65d4e50525c
+      revision: 9c5abb35b5ffb0326e89e2de0504bad8b9253d5d
       import:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.


### PR DESCRIPTION
Update to latest hal_silabs and zephyr revisions. This should also (again) fix the upstream build workflow.