### PR TITLE
doc: Add guidelines for application thread priority

### DIFF
--- a/samples/wifi_ble_coex_demo/README.rst
+++ b/samples/wifi_ble_coex_demo/README.rst
@@ -20,6 +20,10 @@ Socket Support
 **************
 Maximum 2 TLS sockets are supported in Coex mode.
 
+Thread Priority Guidelines
+**************************
+* The Wi-Fi application thread must have **lower priority** than the Wi-Fi thread to ensure smooth and uninterrupted Wi-Fi operations.
+
 Building and Running
 ********************
 This sample can be found under :zephyr_file:`samples/bluetooth/wifi_ble_coex_throughput`

--- a/samples/wifi_provisioning_over_ble/README.rst
+++ b/samples/wifi_provisioning_over_ble/README.rst
@@ -17,6 +17,10 @@ Requirements
 * A mobile app or central device to send Wi-Fi credentials over BLE
 * Wi-Fi Access Point for connectivity testing.
 
+Thread Priority Guidelines
+**************************
+* The Wi-Fi application thread must have **lower priority** than the Wi-Fi thread to ensure smooth and uninterrupted Wi-Fi operations.
+
 Building and Running
 ********************
 This sample can be found under :zephyr_file:`samples/wifi_provisioning_over_ble`


### PR DESCRIPTION
Documented that the application thread must run at a lower priority than the Wi-Fi command handling threads to ensure smooth operation.