### PR TITLE
manifest: Update to track downstream main tree

### DIFF
--- a/.github/workflows/upstream-build.yml
+++ b/.github/workflows/upstream-build.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: zephyr-silabs
         shell: bash
         run: |
-          yq -i '(.manifest.projects[] | select(.name == "zephyr") | .revision) = "main"' west.yml
+          yq -i '(.manifest.projects[] | select(.name == "zephyr")) |= (.remote = "zephyrproject-rtos" | .revision = "main")' west.yml
 
       - name: Setup Zephyr project
         uses: zephyrproject-rtos/action-zephyr-setup@v1

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
       revision: 43bb1e577e2accfaa135464bac181ed2a0cc0489
       path: modules/crypto/mbedtls
     - name: zephyr
-      remote: zephyrproject-rtos
+      remote: silabs
       revision: 9b7d73cf676ea1a420a05687d4df8e37da0a958a
       import:
         # By using name-allowlist we can clone only the modules that are


### PR DESCRIPTION
Use downstream main tree.
Ensure upstream build job still uses upstream main tree.