### PR TITLE
zephyr: Include samples and tests in the module definition

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -21,3 +21,7 @@ build:
     # Zephyr will use the `<soc_root>/soc` for additional socs. The `.` is the
     # root of this repository.
     soc_root: .
+samples:
+  - samples
+tests:
+  - tests


### PR DESCRIPTION
We have both sample and test apps. Be sure to include the directories for these into the module definition so that they can be leveraged by twister and compliance checking.