### PR TITLE
modules: hal_silabs: Set correct SE mailbox priority

### DIFF
--- a/modules/hal_silabs/simplicity_sdk/inc/sli_psec_osal_zephyr.h
+++ b/modules/hal_silabs/simplicity_sdk/inc/sli_psec_osal_zephyr.h
@@ -12,7 +12,8 @@
 #define SLI_PSEC_OSAL_NON_BLOCKING (0)
 
 #if DT_IRQ_HAS_NAME(DT_NODELABEL(se), sembrx)
-#define SE_MANAGER_USER_SEMBRX_IRQ_PRIORITY DT_IRQ_BY_NAME(DT_NODELABEL(se), sembrx, priority)
+#define SE_MANAGER_USER_SEMBRX_IRQ_PRIORITY                                                        \
+	(DT_IRQ_BY_NAME(DT_NODELABEL(se), sembrx, priority) + CONFIG_ZERO_LATENCY_LEVELS + 1)
 #endif
 
 typedef enum {


### PR DESCRIPTION
The SE mailbox priority must be lower than the base priority to ensure mutual exclusion. Interpret the Devicetree priority value as for a normal interrupt, not a zero-latency interrupt.

This issue was masked by the mailbox priority previously being 3 in SoC Devicetree files, which made it have a normal priority despite being interpreted as a zero-latency interrupt.