### PR TITLE
manifest: Update main tree with downstream patches

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -25,7 +25,7 @@ manifest:
   projects:
     - name: zephyr
       remote: silabs
-      revision: 684c9e8f32e4373a21098559f748f06915f950c9
+      revision: f0f8d066d00cabcde966bfe9238c8f4894cb49b1
       import:
         # Simplicity SDK for Zephyr imports the Zephyr main tree at the
         # revision given above. Only the modules named below are imported.
@@ -45,7 +45,7 @@ manifest:
           - zcbor
     - name: hal_silabs
       remote: silabs
-      revision: f5201210afa1319ed8dd8dbe21682bcb63b25771
+      revision: 8b00abb4b3ce7d216bb5ce6c4be7a4b6abaddf5e
       path: modules/hal/silabs
     - name: mcuboot
       remote: silabs


### PR DESCRIPTION
Update main tree to add downstream patches cherry-picked from the upstream after Zephyr 4.4.0 release.

This update brings in the following commits:

```
f0f8d066d00 boards: silabs: xg24_ek2703a: Fix led polarity
8a29bc2c63e drivers: wifi: siwx91x: include logging/log.h
4f5c8d760f5 drivers: gpio: siwx91x: enable uulp gpio wakeup interrupt feature
adad49d1612 boards: silabs: xg24_dk2601b: Add aliases for i2c sensors
dc193a207f4 boards: silabs: xg24_dk2601b: Add bmp384 pressure sensor
ad04e5c58bd mgmt: mcumgr: grp: fs_mgmt: Fix not checking if write completed
200e1693fcd modules: openthread: Fix alarm counter compilation
49e47695a40 dts: arm: silabs: siwg917: remove qspi-80mhz-clk property in nwp node
8caacf8aa04 dts: arm: silabs: siwx91x: Use 80 MHz NWP clock
719d1d266d6 Bluetooth: Host: shell: Add error handling for scan command parsing
d9a707ff4c7 Bluetooth: Host: shell: Fix scan timeout parameter behaviour
81f431f75c3 Bluetooth: Host: shell: Add scan interval and window options
c4fe4a4a506 Bluetooth: Host: shell: Use getopt for scan command
855964e3c7a Bluetooth: Host: shell: Allow specifying advertising interval
ad9e04c1db5 tests: drivers: gpio: Remove overlays for xg29 boards
6b94501fb3d Bluetooth: Host: Fix missing responder address type
230c05fadfe drivers: wifi: siwx91x: always enable instant BG scan for connected scan
1ff18423b81 drivers: wifi: siwx91x: raise NET_EVENT_WIFI_TWT from WiseConnect
23d6fb75df2 manifest: Update hal_silabs
e1d175a6da1 samples: code_relocation_nocopy: Allow flash to not start at 0
```